### PR TITLE
feat: Add playlist thumbnail support

### DIFF
--- a/main.py
+++ b/main.py
@@ -36,6 +36,9 @@ def cli():
 @click.option(
     "--save-to-sync", "-s", is_flag=True, help="Save to list of playlist to sync"
 )
+@click.option(
+    "--thumbnail", "-t", is_flag=True, help="Set playlist thumbnail"
+)
 def create(
     spotify_playlist_id: str,
     public: bool,
@@ -44,6 +47,7 @@ def create(
     description: str,
     only_link: bool,
     save_to_sync: bool,
+    thumbnail: bool,
 ):
     """Create a YouTube Playlist from Spotify Playlist"""
 
@@ -113,6 +117,15 @@ def create(
     if save_to_sync:
         manager.add_playlist(spotify_playlist_id, youtube_playlist_id, spotify_playlist.name, name, f"https://open.spotify.com/playlist/{spotify_playlist_id}", f"https://www.youtube.com/playlist?list={youtube_playlist_id}")
         manager.commit()
+
+    if thumbnail:
+        if spotify_playlist.thumbnail_url:
+            youtube.set_playlist_thumbnail(youtube_playlist_id, spotify_playlist.thumbnail_url)
+            if not only_link:
+                click.secho("Thumbnail set", fg="green")
+        else:
+            if not only_link:
+                click.secho("No thumbnail found on Spotify", fg="yellow")
 
 
 @click.command()

--- a/spotify_client.py
+++ b/spotify_client.py
@@ -13,6 +13,7 @@ class Playlist:
     name: str
     description: str
     tracks: list[str]
+    thumbnail_url: str
 
 
 class SpotifyClient:
@@ -34,4 +35,9 @@ class SpotifyClient:
                 [artist["name"] for artist in track["track"]["artists"]]
             )
             queries.append(f"{track_name} by {artists}")
-        return Playlist(playlist["name"], playlist["description"], queries)
+
+        thumbnail_url = None
+        if playlist["images"]:
+            thumbnail_url = playlist["images"][0]["url"]
+
+        return Playlist(playlist["name"], playlist["description"], queries, thumbnail_url)

--- a/youtube_client.py
+++ b/youtube_client.py
@@ -1,5 +1,7 @@
 import os
 import json
+import io
+import requests
 
 from pytube import Search
 from pytube.contrib.search import logger
@@ -7,6 +9,7 @@ from pytube.contrib.search import logger
 from google_auth_oauthlib.flow import InstalledAppFlow
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
+from googleapiclient.http import MediaIoBaseUpload
 
 logger.disabled = True
 
@@ -102,3 +105,20 @@ class YouTubeClient:
                 break
 
         return videos
+
+    def set_playlist_thumbnail(self, playlist_id: str, image_url: str):
+        response = requests.get(image_url)
+        image_bytes = io.BytesIO(response.content)
+
+        media = MediaIoBaseUpload(
+            image_bytes, mimetype="image/jpeg", chunksize=1024 * 1024, resumable=True
+        )
+
+        request = self.youtube.playlistImages().insert(
+            part="snippet",
+            body={"snippet": {"playlistId": playlist_id}},
+            media_body=media,
+        )
+
+        response = request.execute()
+        return response


### PR DESCRIPTION
Adds the ability to copy a playlist's thumbnail from Spotify to YouTube.

A new `--thumbnail` flag has been added to the `create` command.

The implementation uses the `playlistImages.insert` method from the YouTube Data API.